### PR TITLE
Fix/display result

### DIFF
--- a/src/Guard.elm
+++ b/src/Guard.elm
@@ -116,12 +116,12 @@ ruleRunner value c constraints =
 
 isValid : Guard e k -> Bool
 isValid { constraints } =
-    List.isEmpty constraints.invalid
+    List.isEmpty (constraints.invalid ++ constraints.none)
 
 
 hasErrors : Guard e k -> Bool
-hasErrors guard =
-    not (isValid guard)
+hasErrors { constraints } =
+    not (List.isEmpty constraints.invalid)
 
 
 listErrors : Guard e k -> List e

--- a/tests/GuardTests.elm
+++ b/tests/GuardTests.elm
@@ -9,13 +9,22 @@ import Test exposing (Test, describe, test)
 suite : Test
 suite =
     let
+        nonValidatedGuard =
+            Guard.new ""
+                [ Guard.constraint "match error" (Rule.match "elm-[a-z]+") ]
+
         guard =
             Guard.new ""
                 [ Guard.constraint "match error" (Rule.match "elm-[a-z]+") ]
                 |> Guard.validate
     in
     describe "Guard tests"
-        [ test "Get input without changes must return exactly same previous value" <|
+        [ test "Non validated guard must raise false" <|
+            \_ ->
+                nonValidatedGuard
+                    |> Guard.isValid
+                    |> Expect.equal False
+        , test "Get input without changes must return exactly same previous value" <|
             \_ ->
                 guard
                     |> Guard.getInput


### PR DESCRIPTION
This PR fixes a bug when checking result before validate the data, for instance:

Code below runs fine, since the data is validated
```elm
Guard.new ""
    [ Guard.constraint "match error" (Rule.match "elm-[a-z]+") ]
    |> Guard.validate
    |> Guard.isValid
--  False
```

... but, if you run the same code without `Guard.validate` an not valid response will raise
```elm
Guard.new ""
    [ Guard.constraint "match error" (Rule.match "elm-[a-z]+") ]
    |> Guard.isValid
--  True
```